### PR TITLE
Adding event and field information to the audit log for a 'verify all action'

### DIFF
--- a/DataResolutionDAO.php
+++ b/DataResolutionDAO.php
@@ -74,6 +74,13 @@ class DataResolutionDAO {
         {
             throw new Exception("Unable to execute query " . mysqli_stmt_error($prepared_resolution) . " $sql");
         }
+
+        ## Logging (modeled after 'DataQuality/data_resolution_popup.php')
+        $logDataValues = json_encode_rc(array('record'=>$record,'event_id'=>$eventid,'field'=>$field));
+
+        // Set event_id in query string for logging purposes only
+        $_GET['event_id'] = $eventid;
+        // Log it
         Logging::logEvent($sql,"redcap_data_quality_resolutions","MANAGE",$record, "", "Verified data value");
     }
     


### PR DESCRIPTION
Tested on my local REDCap instance, and the event and field information is now displayed in the audit log:

![image](https://user-images.githubusercontent.com/20141935/57024088-b80ae680-6c01-11e9-8bd8-0ad8e136bf3b.png)
