### PR TITLE
Issue 3 full logging

### DIFF
--- a/DataResolutionDAO.php
+++ b/DataResolutionDAO.php
@@ -81,7 +81,7 @@ class DataResolutionDAO {
         // Set event_id in query string for logging purposes only
         $_GET['event_id'] = $eventid;
         // Log it
-        Logging::logEvent($sql,"redcap_data_quality_resolutions","MANAGE",$record, "", "Verified data value");
+        Logging::logEvent($sql,"redcap_data_quality_resolutions","MANAGE",$record, $logDataValues, "Verified data value");
     }
     
 }

--- a/DataResolutionDAO.php
+++ b/DataResolutionDAO.php
@@ -74,6 +74,13 @@ class DataResolutionDAO {
         {
             throw new Exception("Unable to execute query " . mysqli_stmt_error($prepared_resolution) . " $sql");
         }
+
+        ## Logging (modeled after 'DataQuality/data_resolution_popup.php')
+        $logDataValues = json_encode_rc(array('record'=>$record,'event_id'=>$eventid,'field'=>$field));
+
+        // Set event_id in query string for logging purposes only
+        $_GET['event_id'] = $eventid;
+        // Log it
         Logging::logEvent($sql,"redcap_data_quality_resolutions","MANAGE",$record, "", "Verified data value");
     }
     


### PR DESCRIPTION
The audit log now contains the event and field information (tested on local REDCap instance):

![image](https://user-images.githubusercontent.com/20141935/57024449-99f1b600-6c02-11e9-935a-61b25bb9c573.png)
